### PR TITLE
1up60hse configurator defaults (#187)

### DIFF
--- a/keymaps/1up60hse_default.json
+++ b/keymaps/1up60hse_default.json
@@ -1,0 +1,28 @@
+{  
+    "keyboard":"1up60hse",
+    "keymap":"1upkeyboards_60hse_default",
+    "layout":"LAYOUT_60_ansi",
+    "layers":[  
+       [  
+          "KC_ESC", "KC_1", "KC_2", "KC_3", "KC_4", "KC_5", "KC_6", "KC_7", "KC_8", "KC_9", "KC_0", "KC_MINS", "KC_EQL", "KC_BSPC",
+          "KC_TAB", "KC_Q", "KC_W", "KC_E", "KC_R", "KC_T", "KC_Y", "KC_U", "KC_I", "KC_O", "KC_P", "KC_LBRC", "KC_RBRC", "KC_BSLS",
+          "MO(1)", "KC_A", "KC_S", "KC_D", "KC_F", "KC_G", "KC_H", "KC_J", "KC_K", "KC_L", "KC_SCLN", "KC_QUOT", "KC_ENT",
+          "KC_LSFT", "KC_Z", "KC_X", "KC_C", "KC_V", "KC_B", "KC_N", "KC_M", "KC_COMM", "KC_DOT", "KC_SLSH", "KC_RSFT",
+          "KC_LCTL", "KC_LGUI", "KC_LALT", "KC_SPC", "KC_RALT", "MO(2)", "KC_RGUI", "KC_LCTL"
+       ],
+       [  
+          "KC_GRV", "KC_F1", "KC_F2", "KC_F3", "KC_F4", "KC_F5", "KC_F6", "KC_F7", "KC_F8", "KC_F9", "KC_F10", "KC_F11", "KC_F12", "KC_TRNS",
+          "KC_TRNS", "KC_TRNS", "KC_UP", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+          "KC_TRNS", "KC_LEFT", "KC_DOWN", "KC_RGHT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+          "KC_LSFT", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+          "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "MO(2)", "KC_TRNS", "KC_TRNS"
+       ],
+       [  
+          "RESET", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+          "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS","KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS",
+          "KC_CAPS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "BL_STEP", "BL_DEC", "BL_INC", "BL_TOGG", "KC_TRNS", "KC_TRNS", "KC_TRNS", 
+          "KC_TRNS", "KC_TRNS", "KC_TRNS", "RGB_VAD", "RGB_VAI", "RGB_SAD", "RGB_HUD", "RGB_HUI", "RGB_MOD", "RGB_TOG", "KC_TRNS", "KC_TRNS",
+          "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS", "KC_TRNS"
+       ]
+    ]
+ }


### PR DESCRIPTION
* add 1up60hse defaults configurator keymap file

* formatting changes

* change keymap name

* probably a good idea to replace KC_NO with KC_TRNS